### PR TITLE
Info.plist is not necessary for target' bundle.

### DIFF
--- a/example/iTellAFriendDemo.xcodeproj/project.pbxproj
+++ b/example/iTellAFriendDemo.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		6D2192F7152E13F40088C540 /* RootViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6D2192F5152E13F40088C540 /* RootViewController.xib */; };
 		6D2192FA152E13FA0088C540 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D2192F9152E13FA0088C540 /* AppDelegate.m */; };
 		6D219300152E14050088C540 /* iPhoneIcon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6D2192FB152E14050088C540 /* iPhoneIcon@2x.png */; };
-		6D219301152E14050088C540 /* iTellAFriendDemo-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6D2192FC152E14050088C540 /* iTellAFriendDemo-Info.plist */; };
 		6D219302152E14050088C540 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6D2192FE152E14050088C540 /* Localizable.strings */; };
 		6D219303152E14050088C540 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D2192FF152E14050088C540 /* main.m */; };
 		6D3E345214C4F54E0003B72B /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D3E345114C4F54E0003B72B /* UIKit.framework */; };
@@ -205,7 +204,6 @@
 				6D2192F2152E13EC0088C540 /* SettingsViewController.xib in Resources */,
 				6D2192F7152E13F40088C540 /* RootViewController.xib in Resources */,
 				6D219300152E14050088C540 /* iPhoneIcon@2x.png in Resources */,
-				6D219301152E14050088C540 /* iTellAFriendDemo-Info.plist in Resources */,
 				6D219302152E14050088C540 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/iTellAFriend.m
+++ b/src/iTellAFriend.m
@@ -31,6 +31,9 @@ static NSString *const iTellAFriendAppStoreIconImageKey = @"iTellAFriendAppStore
 static NSString *const iTellAppLookupURLFormat = @"http://itunes.apple.com/lookup?country=%@&id=%d";
 static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.com/us/app/%@/id%d?mt=8&ls=1";
 
+@interface iTellAFriend ()
+- (void)promptIfNetworkAvailable;
+@end
 
 @implementation iTellAFriend 
 

--- a/src/iTellAFriend.m
+++ b/src/iTellAFriend.m
@@ -324,7 +324,10 @@ static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.
       
       [defaults setObject:applicationKey forKey:iTellAFriendAppKey];
       
+#if !__has_feature(objc_arc)
       // release json
+      [json release];
+#endif
     }
   }
 }

--- a/src/iTellAFriend.m
+++ b/src/iTellAFriend.m
@@ -285,52 +285,55 @@ static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.
 {
   @synchronized (self)
   {
-    NSString *iTunesServiceURL = [NSString stringWithFormat:iTellAppLookupURLFormat, appStoreCountry, appStoreID];
-    
-    NSError *error = nil;
-    NSData *data = [NSData dataWithContentsOfURL:[NSURL URLWithString:iTunesServiceURL] options:NSDataReadingUncached error:&error];
-    if (data)
-    {
-      // convert to string
-      NSString *json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      
-      NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-      
-      // get genre  
-      if (!applicationGenreName)
+    @autoreleasepool {
+      NSString *iTunesServiceURL = [NSString stringWithFormat:iTellAppLookupURLFormat, appStoreCountry, appStoreID];
+
+      NSError *error = nil;
+      NSData *data = [NSData dataWithContentsOfURL:[NSURL URLWithString:iTunesServiceURL] options:NSDataReadingUncached error:&error];
+      if (data)
       {
-        NSString *genreName = [self valueForKey:@"primaryGenreName" inJSON:json];
-        [self performSelectorOnMainThread:@selector(setApplicationGenreName:) withObject:genreName waitUntilDone:YES];
-        [defaults setObject:genreName forKey:iTellAFriendAppGenreNameKey];
-      }
-      
-      if (!appStoreIconImage)
-      {
-        NSString *iconImage = [self valueForKey:@"artworkUrl100" inJSON:json];
-        [self performSelectorOnMainThread:@selector(setAppStoreIconImage:) withObject:iconImage waitUntilDone:YES];
-        [defaults setObject:iconImage forKey:iTellAFriendAppStoreIconImageKey];
-      }
-      
-      if (!applicationName)
-      {
-        NSString *appName = [self valueForKey:@"trackName" inJSON:json];
-        [self performSelectorOnMainThread:@selector(setApplicationName:) withObject:appName waitUntilDone:YES];
-        [defaults setObject:appName forKey:iTellAFriendAppNameKey];
-      }
-      
-      if (!applicationSellerName)
-      {
-        NSString *sellerName = [self valueForKey:@"sellerName" inJSON:json];
-        [self performSelectorOnMainThread:@selector(setApplicationSellerName:) withObject:sellerName waitUntilDone:YES];
-        [defaults setObject:sellerName forKey:iTellAFriendAppSellerNameKey];
-      }
-      
-      [defaults setObject:applicationKey forKey:iTellAFriendAppKey];
-      
+        // convert to string
+        NSString *json = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+
+        // get genre
+        if (!applicationGenreName)
+        {
+          NSString *genreName = [self valueForKey:@"primaryGenreName" inJSON:json];
+          [self performSelectorOnMainThread:@selector(setApplicationGenreName:) withObject:genreName waitUntilDone:YES];
+          [defaults setObject:genreName forKey:iTellAFriendAppGenreNameKey];
+        }
+
+        if (!appStoreIconImage)
+        {
+          NSString *iconImage = [self valueForKey:@"artworkUrl100" inJSON:json];
+          [self performSelectorOnMainThread:@selector(setAppStoreIconImage:) withObject:iconImage waitUntilDone:YES];
+          [defaults setObject:iconImage forKey:iTellAFriendAppStoreIconImageKey];
+        }
+
+        if (!applicationName)
+        {
+          NSString *appName = [self valueForKey:@"trackName" inJSON:json];
+          [self performSelectorOnMainThread:@selector(setApplicationName:) withObject:appName waitUntilDone:YES];
+          [defaults setObject:appName forKey:iTellAFriendAppNameKey];
+        }
+
+        if (!applicationSellerName)
+        {
+          NSString *sellerName = [self valueForKey:@"sellerName" inJSON:json];
+          [self performSelectorOnMainThread:@selector(setApplicationSellerName:) withObject:sellerName waitUntilDone:YES];
+          [defaults setObject:sellerName forKey:iTellAFriendAppSellerNameKey];
+        }
+
+        [defaults setObject:applicationKey forKey:iTellAFriendAppKey];
+        
 #if !__has_feature(objc_arc)
-      // release json
-      [json release];
+        // release json
+        [json release];
 #endif
+      }
+
     }
   }
 }

--- a/src/iTellAFriend.m
+++ b/src/iTellAFriend.m
@@ -32,6 +32,7 @@ static NSString *const iTellAppLookupURLFormat = @"http://itunes.apple.com/looku
 static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.com/us/app/%@/id%d?mt=8&ls=1";
 
 @interface iTellAFriend ()
+- (NSString *)messageBody;
 - (void)promptIfNetworkAvailable;
 @end
 
@@ -124,7 +125,7 @@ static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.
   [picker setSubject:self.messageTitle];
 
   
-  [picker setMessageBody:self.message isHTML:YES];
+  [picker setMessageBody:[self messageBody] isHTML:YES];
   
   return picker;
 }
@@ -146,9 +147,17 @@ static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.
 
 - (NSString *)message
 {
+  if (message) {
+    return message;
+  }
+  return @"Check out this application on the App Store:";
+}
+
+- (NSString *)messageBody
+{
   // Fill out the email body text
   NSMutableString *emailBody = [NSMutableString stringWithFormat:@"<div> \n"
-                                "<p style=\"font:17px Helvetica,Arial,sans-serif\">Check out this application on the App Store:</p> \n"
+                                "<p style=\"font:17px Helvetica,Arial,sans-serif\">%@</p> \n"
                                 "<table border=\"0\"> \n"
                                 "<tbody> \n"
                                 "<tr> \n"
@@ -187,6 +196,7 @@ static NSString *const iTellAFriendiOSAppStoreURLFormat = @"http://itunes.apple.
                                 "</tbody> \n"
                                 "</table> \n"
                                 "</div>", 
+                                self.message,
                                 [self.appStoreURL absoluteString], 
                                 self.appStoreIconImage, 
                                 [self.appStoreURL absoluteString], 


### PR DESCRIPTION
Hi,

When I build your iTellAFriend example, the following warnings occurred:

`Warning: The Copy Bundle Resources build phase contains
 this target's Info.plist file 'iTellAFriendDemo/iTellAFriendDemo-Info.plist'.`

So, I removed info.plist from the Copy Bundle Resources build phase.
I would appreciate it that you apply my patch.

Anyway, this is a good library.
Thanks,
