### PR TITLE
Fix CocoaLumberjack definition

### DIFF
--- a/src/iTellAFriend.h
+++ b/src/iTellAFriend.h
@@ -21,18 +21,6 @@
 #import <MessageUI/MessageUI.h>
 #import <StoreKit/StoreKit.h>
 
-#ifdef DEBUG
-// First, check if we can use Cocoalumberjack for logging
-#ifdef LOG_VERBOSE
-extern int ddLogLevel;
-#define ITELLLog(...)  DDLogVerbose(__VA_ARGS__)
-#else
-#define ITELLLog(...) NSLog(@"%s(%p) %@", __PRETTY_FUNCTION__, self, [NSString stringWithFormat:__VA_ARGS__])
-#endif
-#else
-#define ITELLLog(...) ((void)0)
-#endif
-
 @interface iTellAFriend : NSObject <MFMailComposeViewControllerDelegate, SKStoreProductViewControllerDelegate, UIAlertViewDelegate> {
   NSString *appStoreCountry;
   NSString *applicationName;

--- a/src/iTellAFriend.m
+++ b/src/iTellAFriend.m
@@ -24,6 +24,18 @@
 #error This class requires automatic reference counting
 #endif
 
+#ifdef DEBUG
+// First, check if we can use Cocoalumberjack for logging
+#ifdef LOG_VERBOSE
+extern int ddLogLevel;
+#define ITELLLog(...)  DDLogVerbose(__VA_ARGS__)
+#else
+#define ITELLLog(...) NSLog(@"%s(%p) %@", __PRETTY_FUNCTION__, self, [NSString stringWithFormat:__VA_ARGS__])
+#endif
+#else
+#define ITELLLog(...) ((void)0)
+#endif
+
 static iTellAFriend *sharedInstance = nil;
 
 static NSString *const iTellAFriendAppIdKey = @"iTellAFriendAppIdKey";


### PR DESCRIPTION
Preprocessor definitions for CocoaLumberjack is move to .m file.

Problem description:
If project has a dependency to iTellAFriend and own global definition in

``` objective-c
//Constants.h
extern const int ddLogLevel;

//Constants.m
#ifdef DEBUG
static const int ddLogLevel = LOG_LEVEL_VERBOSE;
#else
static const int ddLogLevel = LOG_LEVEL_WARN;
#endif
```

Importing headers (Constants.h & iTellAFriend.h) will cause compilation error:

```
Redefinition of 'ddLogLevel' with a different type: 'int' vs 'const int'
```

Your definition of CocoaLumberjack is not described in README and as I understand added for own purposes.

So, I moved it to .m to avoid such possible conflicts.
